### PR TITLE
Visually center card(s) on X-Axis, fix overflow

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -186,7 +186,7 @@ div.two-card-container,
 div.release-page-card-container {
     display: grid;
     grid-template-columns: 1fr;
-    margin: 0 3em 1em 3em;
+    margin-inline: auto;
     will-change: transform !important;
 }
 
@@ -264,7 +264,6 @@ div.release-page-card-container {
 }
 
 div.card-content {
-    margin-left: 0.5em;
     font-size: calc(17px + 0.390625vw);
 }
 


### PR DESCRIPTION
Previously, due to the chosen values for `margin`, the card-container was overflowing and not visually centered. Card Contents also were not centered due to a 0.5em margin on the left. This was especially noticeable on the new page that has images with a border, making it very evident that the contents were offcenter.

Though, **these decisions might have been made with a different intent for the design**, as such these (admittely small) changes may not fit the desired look.

For a comparison, some images to make the changes more evident:
![PR-1](https://github.com/user-attachments/assets/375050f6-f414-4d12-b8a7-b715adb1b01c)
> Comparison between signalupdatesinfo.com (current `HEAD`, top-half) versus local copy with the PR (lower-half)

![PR-2](https://github.com/user-attachments/assets/b1179b6e-066a-421a-8a39-fba4d269c418)
> Visual preview of the overflow. Content goes into the `margin` area.