### PR TITLE
add alt-text to chat-folders.html

### DIFF
--- a/news/chat-folders.html
+++ b/news/chat-folders.html
@@ -73,8 +73,8 @@
                     <p>Here's a first look at chat folders thanks to screenshots from <a target="_blank"
                             href="https://wetdry.world/@cyrus">@cyrus</a> </p>
                     <div class="two-image">
-                        <img src="/assets/images/screenshots/chat-folders-1.png">
-                        <img src="/assets/images/screenshots/chat-folders-2.png">
+                        <img src="/assets/images/screenshots/chat-folders-1.png" alt="Two screenshots showing the new chat folder feature in Signal. The first screenshot shows three folders at the top of the conversation list. The second screenshot shows the menu that appear when long-pressing on a chat folder. The menu includes options to customize the folder.">
+                        <img src="/assets/images/screenshots/chat-folders-2.png" alt="A screenshot showing the new chat folder feature in Signal. The screenshot shows the 'Chat folders' settings menu in Signal. It lists the current chat folders, and has a 'Create a folder button'. Additionally, there is a 'Suggested folders' section that suggests chat folders.">
                     </div>
                     <em> Please note that this feature is unreleased and in active development, so the final design and
                         functionality may change.</em>


### PR DESCRIPTION
This adds alt-text to the two images in `/news/chat-folders.html`, taken from mastodon:
https://mastodon.world/@SignalUpdateInfo/113320058624345162